### PR TITLE
Fix bug

### DIFF
--- a/deploy/bin-packing-plugin.yaml
+++ b/deploy/bin-packing-plugin.yaml
@@ -152,7 +152,7 @@ data:
   scheduler-config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1alpha1
     kind: KubeSchedulerConfiguration
-    schedulerName: Bin-Packing-Plugin
+    schedulerName: sample-scheduler
     leaderElection:
       leaderElect: true
       lockObjectName: sample-scheduler
@@ -164,6 +164,9 @@ data:
       score:
         enabled:
         - name: "Bin-Packing-Plugin"
+    pluginConfig:
+    - name: "sample-scheduler"
+      args: {"master": "master", "kubeconfig": "kubeconfig"} 
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/deploy/bin-packing-plugin.yaml
+++ b/deploy/bin-packing-plugin.yaml
@@ -193,7 +193,7 @@ spec:
             name: scheduler-config
       containers:
         - name: scheduler-ctrl
-          image: docker.io/library/bin-packing-plugin:1.0.1
+          image: docker.io/destinysky/scheduler:1.0.3
           imagePullPolicy: IfNotPresent
           args:
             - bin-packing-plugin

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -25,7 +25,7 @@ func (bppl *BinPackingPlugin) Name() string {
 	return Name
 }
 
-func (bppl *BinPackingPlugin) Less(pInfo1, pInfo2 *framework.PodInfo) bool {
+func (bppl *BinPackingPlugin) Less(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
 	/* 排序pod */
 	p1 := pod.GetPodPriority(pInfo1.Pod)
 	p2 := pod.GetPodPriority(pInfo2.Pod)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -74,7 +74,7 @@ func (bppl *BinPackingPlugin) Score(ctx context.Context, state *framework.CycleS
 	if err != nil {
 		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
 	}
-	podNum := len(nodeInfo.Pods())
+	podNum := len(nodeInfo.Pods)
 	return int64(podNum * 10), nil
 }
 
@@ -108,7 +108,7 @@ func (bppl *BinPackingPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return bppl
 }
 
-func New(configuration *runtime.Unknown, f framework.FrameworkHandle) (framework.Plugin, error) {
+func New(configuration runtime.Object, f framework.FrameworkHandle) (framework.Plugin, error) {
 	return &BinPackingPlugin{
 		handle: f,
 	}, nil

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -22,7 +22,7 @@ func (bppl *BinPackingPlugin) Name() string {
 	return Name
 }
 
-func (bppl *BinPackingPlugin) Less(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
+func (bppl *BinPackingPlugin) Less(pInfo1, pInfo2 *framework.PodInfo) bool {
 	/* 排序pod */
 	p1 := pod.GetPodPriority(pInfo1.Pod)
 	p2 := pod.GetPodPriority(pInfo2.Pod)
@@ -71,7 +71,7 @@ func (bppl *BinPackingPlugin) Score(ctx context.Context, state *framework.CycleS
 	if err != nil {
 		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("getting node %q from Snapshot: %v", nodeName, err))
 	}
-	podNum := len(nodeInfo.Pods)
+	podNum := len(nodeInfo.Pods())
 	return int64(podNum * 10), nil
 }
 
@@ -79,7 +79,7 @@ func (bppl *BinPackingPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 
-func New(configuration runtime.Object, f framework.FrameworkHandle) (framework.Plugin, error) {
+func New(configuration *runtime.Unknown, f framework.FrameworkHandle) (framework.Plugin, error) {
 	return &BinPackingPlugin{
 		handle: f,
 	}, nil


### PR DESCRIPTION
Fix five bugs in plugin.go and bin-packing-plugin.yaml, which cause a failed make and always queuing pods. The code was tested on k8s v1.19.3.

1. plugin.go: line 25: change "QueuedPodInfo" to "PodInfo"

2. plugin.go: line 74: change "nodeInfo.Pods" to "nodeInfo.Pods()"

3. plugin.go: line 82: change "runtime.Object" to "*runtime.Unknown"

4. bin-packing-plugin. yaml: line 155: change schedulerName from "Bin-Packing-Plugin" to "sample-scheduler"

5. bin-packing-plugin. yaml: line 167-169:  add pluginConfig